### PR TITLE
CMakeLists: Revamp CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,93 +1,208 @@
 cmake_minimum_required(VERSION 3.8)
+
 project(opus)
 
 option(FIXED_POINT "Use fixed-point code (for device with less powerful FPU" NO)
 option(USE_ALLOCA "Use alloca for stack arrays (on non-C99 compilers)" NO)
 
-set(CELT_SOURCES celt/bands.c celt/celt.c celt/cwrs.c celt/entcode.c celt/entdec.c celt/entenc.c
-    celt/kiss_fft.c celt/laplace.c celt/mathops.c celt/mdct.c celt/modes.c celt/pitch.c
-    celt/celt_lpc.c celt/quant_bands.c celt/rate.c celt/vq.c celt/celt_decoder.c celt/celt_encoder.c)
+add_library(opus STATIC
+    # CELT sources
+    celt/bands.c
+    celt/celt.c
+    celt/celt_decoder.c
+    celt/celt_encoder.c
+    celt/celt_lpc.c
+    celt/cwrs.c
+    celt/entcode.c
+    celt/entdec.c
+    celt/entenc.c
+    celt/kiss_fft.c
+    celt/laplace.c
+    celt/mathops.c
+    celt/mdct.c
+    celt/modes.c
+    celt/pitch.c
+    celt/quant_bands.c
+    celt/rate.c
+    celt/vq.c
 
-set(SILK_SOURCES silk/CNG.c silk/code_signs.c silk/init_decoder.c silk/decode_core.c
-    silk/decode_frame.c silk/decode_parameters.c silk/decode_indices.c silk/decode_pulses.c
-    silk/decoder_set_fs.c silk/dec_API.c silk/enc_API.c silk/encode_indices.c silk/encode_pulses.c
-    silk/gain_quant.c silk/interpolate.c silk/LP_variable_cutoff.c silk/NLSF_decode.c silk/NSQ.c
-    silk/NSQ_del_dec.c silk/PLC.c silk/shell_coder.c silk/tables_gain.c silk/tables_LTP.c
-    silk/tables_NLSF_CB_NB_MB.c silk/tables_NLSF_CB_WB.c silk/tables_other.c silk/tables_pitch_lag.c
-    silk/tables_pulses_per_block.c silk/VAD.c silk/control_audio_bandwidth.c silk/quant_LTP_gains.c
-    silk/VQ_WMat_EC.c silk/HP_variable_cutoff.c silk/NLSF_encode.c silk/NLSF_VQ.c silk/NLSF_unpack.c
-    silk/NLSF_del_dec_quant.c silk/process_NLSFs.c silk/stereo_LR_to_MS.c silk/stereo_MS_to_LR.c
-    silk/check_control_input.c silk/control_SNR.c silk/init_encoder.c silk/control_codec.c
-    silk/A2NLSF.c silk/ana_filt_bank_1.c silk/biquad_alt.c silk/bwexpander_32.c silk/bwexpander.c
-    silk/decode_pitch.c silk/inner_prod_aligned.c silk/lin2log.c silk/log2lin.c
-    silk/LPC_analysis_filter.c silk/LPC_inv_pred_gain.c silk/table_LSF_cos.c silk/NLSF2A.c
-    silk/NLSF_stabilize.c silk/NLSF_VQ_weights_laroia.c silk/pitch_est_tables.c silk/resampler.c
-    silk/resampler_down2_3.c silk/resampler_down2.c silk/resampler_private_AR2.c
-    silk/resampler_private_down_FIR.c silk/resampler_private_IIR_FIR.c
-    silk/resampler_private_up2_HQ.c silk/resampler_rom.c silk/sigm_Q15.c silk/sort.c
-    silk/sum_sqr_shift.c silk/stereo_decode_pred.c silk/stereo_encode_pred.c
-    silk/stereo_find_predictor.c silk/stereo_quant_pred.c silk/LPC_fit.c)
+    # SILK sources
+    silk/A2NLSF.c
+    silk/CNG.c
+    silk/HP_variable_cutoff.c
+    silk/LPC_analysis_filter.c
+    silk/LPC_fit.c
+    silk/LPC_inv_pred_gain.c
+    silk/LP_variable_cutoff.c
+    silk/NLSF2A.c
+    silk/NLSF_VQ.c
+    silk/NLSF_VQ_weights_laroia.c
+    silk/NLSF_decode.c
+    silk/NLSF_del_dec_quant.c
+    silk/NLSF_encode.c
+    silk/NLSF_stabilize.c
+    silk/NLSF_unpack.c
+    silk/NSQ.c
+    silk/NSQ_del_dec.c
+    silk/PLC.c
+    silk/VAD.c
+    silk/VQ_WMat_EC.c
+    silk/ana_filt_bank_1.c
+    silk/biquad_alt.c
+    silk/bwexpander.c
+    silk/bwexpander_32.c
+    silk/check_control_input.c
+    silk/code_signs.c
+    silk/control_SNR.c
+    silk/control_audio_bandwidth.c
+    silk/control_codec.c
+    silk/dec_API.c
+    silk/decode_core.c
+    silk/decode_frame.c
+    silk/decode_indices.c
+    silk/decode_parameters.c
+    silk/decode_pitch.c
+    silk/decode_pulses.c
+    silk/decoder_set_fs.c
+    silk/enc_API.c
+    silk/encode_indices.c
+    silk/encode_pulses.c
+    silk/gain_quant.c
+    silk/init_decoder.c
+    silk/init_encoder.c
+    silk/inner_prod_aligned.c
+    silk/interpolate.c
+    silk/lin2log.c
+    silk/log2lin.c
+    silk/pitch_est_tables.c
+    silk/process_NLSFs.c
+    silk/quant_LTP_gains.c
+    silk/resampler.c
+    silk/resampler_down2.c
+    silk/resampler_down2_3.c
+    silk/resampler_private_AR2.c
+    silk/resampler_private_IIR_FIR.c
+    silk/resampler_private_down_FIR.c
+    silk/resampler_private_up2_HQ.c
+    silk/resampler_rom.c
+    silk/shell_coder.c
+    silk/sigm_Q15.c
+    silk/sort.c
+    silk/stereo_LR_to_MS.c
+    silk/stereo_MS_to_LR.c
+    silk/stereo_decode_pred.c
+    silk/stereo_encode_pred.c
+    silk/stereo_find_predictor.c
+    silk/stereo_quant_pred.c
+    silk/sum_sqr_shift.c
+    silk/table_LSF_cos.c
+    silk/tables_LTP.c
+    silk/tables_NLSF_CB_NB_MB.c
+    silk/tables_NLSF_CB_WB.c
+    silk/tables_gain.c
+    silk/tables_other.c
+    silk/tables_pitch_lag.c
+    silk/tables_pulses_per_block.c
+
+    # Opus sources
+    src/analysis.c
+    src/mlp.c
+    src/mlp_data.c
+    src/opus.c
+    src/opus_decoder.c
+    src/opus_encoder.c
+    src/opus_multistream.c
+    src/opus_multistream_decoder.c
+    src/opus_multistream_encoder.c
+    src/repacketizer.c
+)
 
 if (DEBUG)
-	list(APPEND SILK_SOURCES silk/debug.c)
-endif (DEBUG)
+    target_sources(opus PRIVATE silk/debug.c)
+endif()
+
 
 if (FIXED_POINT)
+    target_sources(opus PRIVATE
+        silk/fixed/LTP_analysis_filter_FIX.c
+        silk/fixed/LTP_scale_ctrl_FIX.c
+        silk/fixed/apply_sine_window_FIX.c
+        silk/fixed/autocorr_FIX.c
+        silk/fixed/burg_modified_FIX.c
+        silk/fixed/corrMatrix_FIX.c
+        silk/fixed/encode_frame_FIX.c
+        silk/fixed/find_LPC_FIX.c
+        silk/fixed/find_LTP_FIX.c
+        silk/fixed/find_pitch_lags_FIX.c
+        silk/fixed/find_pred_coefs_FIX.c
+        silk/fixed/k2a_FIX.c
+        silk/fixed/k2a_Q16_FIX.c
+        silk/fixed/noise_shape_analysis_FIX.c
+        silk/fixed/pitch_analysis_core_FIX.c
+        silk/fixed/prefilter_FIX.c
+        silk/fixed/process_gains_FIX.c
+        silk/fixed/regularize_correlations_FIX.c
+        silk/fixed/residual_energy16_FIX.c
+        silk/fixed/residual_energy_FIX.c
+        silk/fixed/schur64_FIX.c
+        silk/fixed/schur_FIX.c
+        silk/fixed/solve_LS_FIX.c
+        silk/fixed/vector_ops_FIX.c
+        silk/fixed/warped_autocorrelation_FIX.c
+    )
+else()
+    target_sources(opus PRIVATE
+        silk/float/LPC_analysis_filter_FLP.c
+        silk/float/LPC_inv_pred_gain_FLP.c
+        silk/float/LTP_analysis_filter_FLP.c
+        silk/float/LTP_scale_ctrl_FLP.c
+        silk/float/apply_sine_window_FLP.c
+        silk/float/autocorrelation_FLP.c
+        silk/float/burg_modified_FLP.c
+        silk/float/bwexpander_FLP.c
+        silk/float/corrMatrix_FLP.c
+        silk/float/encode_frame_FLP.c
+        silk/float/energy_FLP.c
+        silk/float/find_LPC_FLP.c
+        silk/float/find_LTP_FLP.c
+        silk/float/find_pitch_lags_FLP.c
+        silk/float/find_pred_coefs_FLP.c
+        silk/float/inner_product_FLP.c
+        silk/float/k2a_FLP.c
+        silk/float/noise_shape_analysis_FLP.c
+        silk/float/pitch_analysis_core_FLP.c
+        silk/float/process_gains_FLP.c
+        silk/float/regularize_correlations_FLP.c
+        silk/float/residual_energy_FLP.c
+        silk/float/scale_copy_vector_FLP.c
+        silk/float/scale_vector_FLP.c
+        silk/float/schur_FLP.c
+        silk/float/sort_FLP.c
+        silk/float/warped_autocorrelation_FLP.c
+        silk/float/wrappers_FLP.c
+    )
+endif()
 
-list(APPEND SILK_SOURCES silk/fixed/LTP_analysis_filter_FIX.c silk/fixed/LTP_scale_ctrl_FIX.c
-    silk/fixed/corrMatrix_FIX.c silk/fixed/encode_frame_FIX.c silk/fixed/find_LPC_FIX.c
-    silk/fixed/find_LTP_FIX.c silk/fixed/find_pitch_lags_FIX.c silk/fixed/find_pred_coefs_FIX.c
-    silk/fixed/noise_shape_analysis_FIX.c silk/fixed/prefilter_FIX.c silk/fixed/process_gains_FIX.c
-    silk/fixed/regularize_correlations_FIX.c silk/fixed/residual_energy16_FIX.c
-    silk/fixed/residual_energy_FIX.c silk/fixed/solve_LS_FIX.c
-    silk/fixed/warped_autocorrelation_FIX.c silk/fixed/apply_sine_window_FIX.c
-    silk/fixed/autocorr_FIX.c silk/fixed/burg_modified_FIX.c silk/fixed/k2a_FIX.c
-    silk/fixed/k2a_Q16_FIX.c silk/fixed/pitch_analysis_core_FIX.c silk/fixed/vector_ops_FIX.c
-    silk/fixed/schur64_FIX.c silk/fixed/schur_FIX.c)
+target_compile_definitions(opus
+PUBLIC
+    -DOPUS_BUILD
+    -DOPUS_VERSION="\\"1.2.0\\""
 
-else (FIXED_POINT)
+PRIVATE
+    # Use C99 intrinsics to speed up float-to-int conversion
+    HAVE_LRINTF
 
-list(APPEND SILK_SOURCES silk/float/apply_sine_window_FLP.c silk/float/corrMatrix_FLP.c
-    silk/float/encode_frame_FLP.c silk/float/find_LPC_FLP.c silk/float/find_LTP_FLP.c
-    silk/float/find_pitch_lags_FLP.c silk/float/find_pred_coefs_FLP.c
-    silk/float/LPC_analysis_filter_FLP.c silk/float/LTP_analysis_filter_FLP.c
-    silk/float/LTP_scale_ctrl_FLP.c silk/float/noise_shape_analysis_FLP.c
-    silk/float/process_gains_FLP.c silk/float/regularize_correlations_FLP.c
-    silk/float/residual_energy_FLP.c
-    silk/float/warped_autocorrelation_FLP.c silk/float/wrappers_FLP.c
-    silk/float/autocorrelation_FLP.c silk/float/burg_modified_FLP.c silk/float/bwexpander_FLP.c
-    silk/float/energy_FLP.c silk/float/inner_product_FLP.c silk/float/k2a_FLP.c
-    silk/float/LPC_inv_pred_gain_FLP.c
-    silk/float/pitch_analysis_core_FLP.c silk/float/scale_copy_vector_FLP.c
-    silk/float/scale_vector_FLP.c silk/float/schur_FLP.c silk/float/sort_FLP.c)
-
-endif (FIXED_POINT)
-
-set(OPUS_SOURCES src/opus.c src/opus_decoder.c src/opus_encoder.c src/opus_multistream.c
-    src/repacketizer.c src/opus_multistream_decoder.c src/opus_multistream_encoder.c
-    src/analysis.c src/mlp.c src/mlp_data.c)
-
-add_definitions(-DOPUS_VERSION="\\"1.2.0\\"")
-# It is strongly recommended to uncomment one of these
-# VAR_ARRAYS: Use C99 variable-length arrays for stack allocation
-# USE_ALLOCA: Use alloca() for stack allocation
-# If none is defined, then the fallback is a non-threadsafe global array
-add_definitions(-DUSE_ALLOCA)
-
-
-# These options affect performance
-# HAVE_LRINTF: Use C99 intrinsics to speed up float-to-int conversion
-add_definitions(-DHAVE_LRINTF)
-
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-
-add_definitions(-DOPUS_BUILD)
+    # It is strongly recommended to use one of these
+    # VAR_ARRAYS: Use C99 variable-length arrays for stack allocation
+    # USE_ALLOCA: Use alloca() for stack allocation
+    # If none is defined, then the fallback is a non-threadsafe global array
+    USE_ALLOCA
+)
 
 if (FIXED_POINT)
-    add_definitions(-DFIXED_POINT=1 -DDISABLE_FLOAT_API)
-endif (FIXED_POINT)
+    target_compile_definitions(opus PRIVATE -DFIXED_POINT=1 -DDISABLE_FLOAT_API)
+endif()
 
-include_directories(include silk silk/float silk/fixed celt src)
+target_include_directories(opus PUBLIC include PRIVATE celt silk silk/fixed silk/float src)
 
-add_library(opus STATIC ${CELT_SOURCES} ${SILK_SOURCES} ${OPUS_SOURCES})
 add_subdirectory(tests)


### PR DESCRIPTION
Notably, this doesn't enable -Wall in MSVC when building it. This way we don't end up with 2000+ warnings in externals.